### PR TITLE
feat(content): integrate Content Enhancement with BE API (closes #42)

### DIFF
--- a/.claude/skills/check-tickets/SKILL.md
+++ b/.claude/skills/check-tickets/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: check-tickets
+description: "Check status of my GitHub issues and PRs. Use when user says 'check tickets', 'check state ticket', 'ticket status', or similar."
+argument-hint: "[--me | --all | username]"
+---
+
+# Check Ticket Status
+
+Check the status of GitHub issues and pull requests for the current repository.
+
+## Arguments
+- No args or `--me`: Show tickets assigned to / authored by the current user
+- `--all`: Show all open tickets in the repo
+- `username`: Show tickets for a specific GitHub user
+
+<args>$ARGUMENTS</args>
+
+## Process
+
+1. **Determine scope** from arguments (default: current user `@me`)
+
+2. **Fetch GitHub Issues** assigned to the target user:
+   ```bash
+   gh issue list --assignee <user> --state all --limit 20
+   ```
+
+3. **Fetch Pull Requests** authored by the target user:
+   ```bash
+   gh pr list --author <user> --state all --limit 20
+   ```
+
+4. **For each OPEN PR**, fetch detailed status:
+   ```bash
+   gh pr view <number> --json title,state,reviews,mergeable,statusCheckRollup
+   ```
+   Extract: CI status, review state, merge conflicts
+
+5. **Present results** in a concise markdown table:
+
+   | # | Feature | Issue | PR | CI | Review | Merge Status |
+   |---|---------|-------|----|----|--------|--------------|
+
+   Then a **summary** section highlighting:
+   - Which PRs are ready to merge
+   - Which PRs have conflicts that need resolving
+   - Which PRs are waiting for review
+   - Any failed CI checks
+
+## Important
+- Use `gh` CLI exclusively (not GitHub API calls)
+- Keep output concise - table + summary only
+- If `--all` flag, skip the `--assignee`/`--author` filter

--- a/lib/data/network/apis/content/content_api.dart
+++ b/lib/data/network/apis/content/content_api.dart
@@ -1,5 +1,6 @@
 import 'package:boilerplate/core/data/network/dio/dio_client.dart';
 import 'package:boilerplate/data/network/constants/endpoints.dart';
+import 'package:boilerplate/domain/entity/content/content_item.dart';
 import 'package:boilerplate/domain/entity/content/content_operation.dart';
 import 'package:boilerplate/domain/entity/content/content_request.dart';
 import 'package:boilerplate/domain/entity/content/content_result.dart';
@@ -9,12 +10,79 @@ class ContentApi {
 
   ContentApi(this._dioClient);
 
-  Future<ContentResult> processContent(ContentRequest request) async {
-    final endpoint = Endpoints.contentOperation(request.operation.apiPath);
+  /// Fetch the user's projects (used to discover the default projectId for
+  /// the Content Enhancement picker — the BE response is a list of project
+  /// objects, optionally wrapped in `{data: [...]}`.
+  Future<List<Map<String, dynamic>>> listProjects() async {
+    final response = await _dioClient.dio.get('/api/projects');
+    return _extractList(response.data);
+  }
+
+  /// Fetch all contents for a project (the picker source). Returns
+  /// items already mapped to the lightweight [ContentItem] projection.
+  Future<List<ContentItem>> listProjectContents(String projectId) async {
+    final response =
+        await _dioClient.dio.get(Endpoints.projectContents(projectId));
+    final raw = _extractList(response.data);
+    return raw.map((e) => ContentItem.fromMap(e, projectId)).toList();
+  }
+
+  List<Map<String, dynamic>> _extractList(dynamic body) {
+    if (body is List) {
+      return body.whereType<Map<String, dynamic>>().toList();
+    }
+    if (body is Map<String, dynamic>) {
+      final data = body['data'] ?? body['items'];
+      if (data is List) {
+        return data.whereType<Map<String, dynamic>>().toList();
+      }
+      // Some endpoints wrap pagination as { data: { items: [...] } }
+      if (data is Map<String, dynamic>) {
+        final items = data['items'];
+        if (items is List) {
+          return items.whereType<Map<String, dynamic>>().toList();
+        }
+      }
+    }
+    return const [];
+  }
+
+  /// Kick off an enhancement operation on an existing content row.
+  ///
+  /// Returns immediately with the job acknowledgement
+  /// (`ContentResult.jobCreated`). Caller must poll [pollByJob] (or, in a
+  /// future iteration, subscribe to the SSE stream) to fetch the regenerated
+  /// body once the underlying N8N flow completes.
+  Future<ContentResult> startProcess(ContentRequest request) async {
+    final endpoint = Endpoints.contentOperation(
+      request.contentId,
+      request.operation.apiPath,
+    );
     final response = await _dioClient.dio.post(
       endpoint,
       data: request.toMap(),
     );
-    return ContentResult.fromMap(response.data as Map<String, dynamic>);
+    final body = response.data as Map<String, dynamic>;
+    final jobId =
+        (body['jobId'] ?? body['job_id'] ?? '').toString();
+    return ContentResult.jobCreated(
+      jobId: jobId,
+      operation: request.operation,
+    );
+  }
+
+  /// Polls the by-job endpoint. Returns null when the job is still running
+  /// (BE responds with 200 + empty / null payload), a populated result once
+  /// the regenerate flow finishes.
+  Future<ContentResult?> pollByJob(String jobId) async {
+    final response = await _dioClient.dio.get(Endpoints.contentByJob(jobId));
+    final data = response.data;
+    if (data == null) return null;
+    if (data is String && data.trim().isEmpty) return null;
+    if (data is Map<String, dynamic>) {
+      if (data.isEmpty) return null;
+      return ContentResult.fromMap(data);
+    }
+    return null;
   }
 }

--- a/lib/data/network/constants/endpoints.dart
+++ b/lib/data/network/constants/endpoints.dart
@@ -16,11 +16,13 @@ class Endpoints {
   // post endpoints
   static const String getPosts = "/posts";
 
-  // content enhancement endpoints (AI service)
-  static const String contentBase = "/api/v1/content";
+  // content enhancement endpoints — match BE PR
+  // GEO-Brand-Visibility/geo-brand-visibility-be#148
+  // Stateless AI text processing under /api/contents/<op>
+  static const String contentBase = "/api/contents";
   static String contentOperation(String op) => "$contentBase/$op";
 
-  // SEO audit endpoints
+  // SEO audit endpoints (Phase 1 placeholders — BE not yet built, see #46)
   static const String seoAudit = "/api/v1/seo/audit";
   static String seoAuditResult(String id) => "/api/v1/seo/audit/$id";
   static String seoCrawler(String url) =>

--- a/lib/data/network/constants/endpoints.dart
+++ b/lib/data/network/constants/endpoints.dart
@@ -18,9 +18,15 @@ class Endpoints {
 
   // content enhancement endpoints — match BE PR
   // GEO-Brand-Visibility/geo-brand-visibility-be#148
-  // Stateless AI text processing under /api/contents/<op>
+  // Reuses the existing regenerate N8N flow: each op operates on an
+  // existing content row identified by `id`. Returns { jobId } async;
+  // poll `contentByJob` for the regenerated body.
   static const String contentBase = "/api/contents";
-  static String contentOperation(String op) => "$contentBase/$op";
+  static String contentOperation(String id, String op) =>
+      "$contentBase/$id/$op";
+  static String contentByJob(String jobId) => "$contentBase/by-job/$jobId";
+  static String projectContents(String projectId) =>
+      "/api/projects/$projectId/contents";
 
   // SEO audit endpoints — Phase 1 placeholders, BE not yet built (see issue #46)
   // The Technical SEO feature audit/crawler endpoints below are scaffolds; the

--- a/lib/data/repository/content/content_repository_impl.dart
+++ b/lib/data/repository/content/content_repository_impl.dart
@@ -1,4 +1,5 @@
 import 'package:boilerplate/data/network/apis/content/content_api.dart';
+import 'package:boilerplate/domain/entity/content/content_item.dart';
 import 'package:boilerplate/domain/entity/content/content_request.dart';
 import 'package:boilerplate/domain/entity/content/content_result.dart';
 import 'package:boilerplate/domain/repository/content/content_repository.dart';
@@ -9,7 +10,22 @@ class ContentRepositoryImpl implements ContentRepository {
   ContentRepositoryImpl(this._contentApi);
 
   @override
-  Future<ContentResult> processContent(ContentRequest request) {
-    return _contentApi.processContent(request);
+  Future<List<Map<String, dynamic>>> listProjects() {
+    return _contentApi.listProjects();
+  }
+
+  @override
+  Future<List<ContentItem>> listProjectContents(String projectId) {
+    return _contentApi.listProjectContents(projectId);
+  }
+
+  @override
+  Future<ContentResult> startProcess(ContentRequest request) {
+    return _contentApi.startProcess(request);
+  }
+
+  @override
+  Future<ContentResult?> pollByJob(String jobId) {
+    return _contentApi.pollByJob(jobId);
   }
 }

--- a/lib/domain/entity/content/content_item.dart
+++ b/lib/domain/entity/content/content_item.dart
@@ -1,0 +1,68 @@
+/// One row from `GET /api/projects/:projectId/contents`.
+///
+/// Lightweight projection used by the Content Enhancement picker — only the
+/// fields the picker needs to render + identify the row for the regenerate
+/// flow. Full BE payload has many more fields; we map them lazily.
+class ContentItem {
+  final String id;
+  final String projectId;
+  final String title;
+  final String body;
+  final String contentType;
+  final String status;
+  final String topicName;
+  final DateTime? createdAt;
+
+  ContentItem({
+    required this.id,
+    required this.projectId,
+    required this.title,
+    required this.body,
+    required this.contentType,
+    required this.status,
+    required this.topicName,
+    this.createdAt,
+  });
+
+  factory ContentItem.fromMap(Map<String, dynamic> map, String projectId) {
+    final topic = map['topic'];
+    final topicName = topic is Map<String, dynamic>
+        ? (topic['name']?.toString() ?? '')
+        : '';
+    return ContentItem(
+      id: map['id']?.toString() ?? '',
+      projectId: projectId,
+      title: (map['title'] as String?)?.trim().isNotEmpty == true
+          ? map['title'] as String
+          : 'Untitled draft',
+      body: map['body'] as String? ?? '',
+      contentType: (map['contentType'] as String? ?? 'BLOG_POST')
+          .replaceAll('_', ' '),
+      status: map['completionStatus'] as String? ??
+          map['status'] as String? ??
+          'DRAFT',
+      topicName: topicName,
+      createdAt: map['createdAt'] != null
+          ? DateTime.tryParse(map['createdAt'] as String)
+          : null,
+    );
+  }
+
+  /// True only when the row can be regenerated/enhanced via the BE flow.
+  /// Backend rejects regenerate if the content has no associated prompt
+  /// (e.g. manually created drafts) and we do not enhance content that is
+  /// still in flight from the original generation.
+  bool get isEnhanceable => status != 'DRAFTING' && status != 'FAILED';
+
+  /// Short preview snippet (first ~140 chars without markdown noise).
+  String get bodyPreview {
+    final stripped = body
+        .replaceAll(RegExp(r'!\[[^\]]*\]\([^\)]*\)'), '')
+        .replaceAll(RegExp(r'\[[^\]]*\]\([^\)]*\)'), '')
+        .replaceAll(RegExp(r'[#*_`>~-]'), ' ')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+    if (stripped.length <= 140) return stripped;
+    return '${stripped.substring(0, 140)}…';
+  }
+}

--- a/lib/domain/entity/content/content_request.dart
+++ b/lib/domain/entity/content/content_request.dart
@@ -1,21 +1,24 @@
 import 'package:boilerplate/domain/entity/content/content_operation.dart';
 
+/// Request to enhance an existing draft content.
+///
+/// The 4 enhancement endpoints reuse the existing N8N regenerate flow on
+/// the BE side, so they require an existing content row (`contentId`).
+/// The operation lives in the URL path; the body only carries optional
+/// hints (tone for enhance/rewrite/humanize, length for summarize).
 class ContentRequest {
-  final String text;
+  final String contentId;
   final ContentOperation operation;
   final Map<String, dynamic>? options;
 
   ContentRequest({
-    required this.text,
+    required this.contentId,
     required this.operation,
     this.options,
   });
 
-  /// BE expects only `text` (and optional tone/length flattened, not nested).
-  /// Operation is in the URL path, not the body.
   Map<String, dynamic> toMap() {
     return {
-      'text': text,
       if (options != null) ...options!,
     };
   }

--- a/lib/domain/entity/content/content_request.dart
+++ b/lib/domain/entity/content/content_request.dart
@@ -11,11 +11,12 @@ class ContentRequest {
     this.options,
   });
 
+  /// BE expects only `text` (and optional tone/length flattened, not nested).
+  /// Operation is in the URL path, not the body.
   Map<String, dynamic> toMap() {
     return {
       'text': text,
-      'operation': operation.apiPath,
-      if (options != null) 'options': options,
+      if (options != null) ...options!,
     };
   }
 }

--- a/lib/domain/entity/content/content_result.dart
+++ b/lib/domain/entity/content/content_result.dart
@@ -1,18 +1,39 @@
 import 'package:boilerplate/domain/entity/content/content_operation.dart';
 
+/// Result of an enhancement operation.
+///
+/// Because the BE delegates to the N8N regenerate flow (async), the initial
+/// API call returns only `jobId` + `operation`. The full result text is
+/// fetched later by polling `/api/contents/by-job/{jobId}` once the worker
+/// finishes — at that point `resultText` is populated.
 class ContentResult {
-  final String resultText;
+  final String jobId;
   final ContentOperation operation;
+  final String resultText;
   final int? tokensUsed;
   final DateTime processedAt;
 
   ContentResult({
-    required this.resultText,
+    required this.jobId,
     required this.operation,
+    this.resultText = '',
     this.tokensUsed,
     required this.processedAt,
   });
 
+  /// Parses the synchronous job-creation response: `{ jobId }`.
+  factory ContentResult.jobCreated({
+    required String jobId,
+    required ContentOperation operation,
+  }) {
+    return ContentResult(
+      jobId: jobId,
+      operation: operation,
+      processedAt: DateTime.now(),
+    );
+  }
+
+  /// Parses the by-job poll response (BE returns the full content row).
   factory ContentResult.fromMap(Map<String, dynamic> map) {
     final operationStr = map['operation'] as String? ?? 'enhance';
     final operation = ContentOperation.values.firstWhere(
@@ -20,12 +41,35 @@ class ContentResult {
       orElse: () => ContentOperation.enhance,
     );
     return ContentResult(
-      resultText: map['result_text'] as String? ?? map['resultText'] as String? ?? map['result'] as String? ?? '',
+      jobId: map['jobId'] as String? ?? map['job_id'] as String? ?? '',
       operation: operation,
+      resultText: map['body'] as String? ??
+          map['result_text'] as String? ??
+          map['resultText'] as String? ??
+          map['result'] as String? ??
+          '',
       tokensUsed: map['tokens_used'] as int?,
       processedAt: map['processed_at'] != null
           ? DateTime.parse(map['processed_at'] as String)
-          : DateTime.now(),
+          : (map['updatedAt'] != null
+              ? DateTime.parse(map['updatedAt'] as String)
+              : DateTime.now()),
+    );
+  }
+
+  ContentResult copyWith({
+    String? jobId,
+    ContentOperation? operation,
+    String? resultText,
+    int? tokensUsed,
+    DateTime? processedAt,
+  }) {
+    return ContentResult(
+      jobId: jobId ?? this.jobId,
+      operation: operation ?? this.operation,
+      resultText: resultText ?? this.resultText,
+      tokensUsed: tokensUsed ?? this.tokensUsed,
+      processedAt: processedAt ?? this.processedAt,
     );
   }
 }

--- a/lib/domain/repository/content/content_repository.dart
+++ b/lib/domain/repository/content/content_repository.dart
@@ -1,6 +1,20 @@
+import 'package:boilerplate/domain/entity/content/content_item.dart';
 import 'package:boilerplate/domain/entity/content/content_request.dart';
 import 'package:boilerplate/domain/entity/content/content_result.dart';
 
 abstract class ContentRepository {
-  Future<ContentResult> processContent(ContentRequest request);
+  /// Fetch user's projects (used to discover the default projectId).
+  Future<List<Map<String, dynamic>>> listProjects();
+
+  /// Fetch the contents picker source for a project.
+  Future<List<ContentItem>> listProjectContents(String projectId);
+
+  /// Kick off the regenerate flow for the given content + operation.
+  /// Returns the job acknowledgement; the actual regenerated body is
+  /// retrieved later via [pollByJob].
+  Future<ContentResult> startProcess(ContentRequest request);
+
+  /// Poll the regenerate job. Returns null while the worker is still
+  /// running, a populated result when finished.
+  Future<ContentResult?> pollByJob(String jobId);
 }

--- a/lib/domain/usecase/content/enhance_content_usecase.dart
+++ b/lib/domain/usecase/content/enhance_content_usecase.dart
@@ -12,10 +12,10 @@ class EnhanceContentUseCase extends UseCase<ContentResult, ContentRequest> {
   @override
   Future<ContentResult> call({required ContentRequest params}) {
     final request = ContentRequest(
-      text: params.text,
+      contentId: params.contentId,
       operation: ContentOperation.enhance,
       options: params.options,
     );
-    return _contentRepository.processContent(request);
+    return _contentRepository.startProcess(request);
   }
 }

--- a/lib/domain/usecase/content/humanize_content_usecase.dart
+++ b/lib/domain/usecase/content/humanize_content_usecase.dart
@@ -12,10 +12,10 @@ class HumanizeContentUseCase extends UseCase<ContentResult, ContentRequest> {
   @override
   Future<ContentResult> call({required ContentRequest params}) {
     final request = ContentRequest(
-      text: params.text,
+      contentId: params.contentId,
       operation: ContentOperation.humanize,
       options: params.options,
     );
-    return _contentRepository.processContent(request);
+    return _contentRepository.startProcess(request);
   }
 }

--- a/lib/domain/usecase/content/rewrite_content_usecase.dart
+++ b/lib/domain/usecase/content/rewrite_content_usecase.dart
@@ -12,10 +12,10 @@ class RewriteContentUseCase extends UseCase<ContentResult, ContentRequest> {
   @override
   Future<ContentResult> call({required ContentRequest params}) {
     final request = ContentRequest(
-      text: params.text,
+      contentId: params.contentId,
       operation: ContentOperation.rewrite,
       options: params.options,
     );
-    return _contentRepository.processContent(request);
+    return _contentRepository.startProcess(request);
   }
 }

--- a/lib/domain/usecase/content/summarize_content_usecase.dart
+++ b/lib/domain/usecase/content/summarize_content_usecase.dart
@@ -12,10 +12,10 @@ class SummarizeContentUseCase extends UseCase<ContentResult, ContentRequest> {
   @override
   Future<ContentResult> call({required ContentRequest params}) {
     final request = ContentRequest(
-      text: params.text,
+      contentId: params.contentId,
       operation: ContentOperation.summarize,
       options: params.options,
     );
-    return _contentRepository.processContent(request);
+    return _contentRepository.startProcess(request);
   }
 }

--- a/lib/presentation/content_enhancement/content_enhancement_screen.dart
+++ b/lib/presentation/content_enhancement/content_enhancement_screen.dart
@@ -1,8 +1,9 @@
 import 'package:boilerplate/di/service_locator.dart';
+import 'package:boilerplate/domain/entity/content/content_item.dart';
 import 'package:boilerplate/domain/entity/content/content_operation.dart';
 import 'package:boilerplate/presentation/content_enhancement/store/content_enhancement_store.dart';
-import 'package:boilerplate/presentation/content_enhancement/widgets/content_input_widget.dart';
-import 'package:boilerplate/presentation/content_enhancement/widgets/content_result_widget.dart';
+import 'package:boilerplate/presentation/content_enhancement/widgets/before_after_widget.dart';
+import 'package:boilerplate/presentation/content_enhancement/widgets/customization_panel.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 
@@ -16,12 +17,12 @@ class ContentEnhancementScreen extends StatefulWidget {
 
 class _ContentEnhancementScreenState extends State<ContentEnhancementScreen> {
   final ContentEnhancementStore _store = getIt<ContentEnhancementStore>();
-  final TextEditingController _textController = TextEditingController();
 
   @override
-  void dispose() {
-    _textController.dispose();
-    super.dispose();
+  void initState() {
+    super.initState();
+    // Fire-and-forget — picker shows a spinner while it resolves.
+    _store.loadAvailableContents();
   }
 
   static const _operationMeta = {
@@ -56,12 +57,20 @@ class _ContentEnhancementScreenState extends State<ContentEnhancementScreen> {
         backgroundColor: Colors.white,
         foregroundColor: Colors.black87,
         elevation: 0,
+        actions: [
+          Observer(
+            builder: (_) => IconButton(
+              icon: const Icon(Icons.refresh),
+              tooltip: 'Reload posts',
+              onPressed: _store.loadingContents
+                  ? null
+                  : () => _store.loadAvailableContents(force: true),
+            ),
+          ),
+        ],
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(1),
-          child: Container(
-            color: Colors.grey.shade200,
-            height: 1,
-          ),
+          child: Container(color: Colors.grey.shade200, height: 1),
         ),
       ),
       body: SingleChildScrollView(
@@ -72,8 +81,12 @@ class _ContentEnhancementScreenState extends State<ContentEnhancementScreen> {
             _buildHeader(),
             const SizedBox(height: 20),
             _buildOperationCards(),
-            const SizedBox(height: 24),
-            _buildInputSection(),
+            const SizedBox(height: 16),
+            _buildCustomizationPanel(),
+            const SizedBox(height: 20),
+            _buildContentPickerSection(),
+            const SizedBox(height: 16),
+            _buildSelectedPreview(),
             const SizedBox(height: 16),
             _buildProcessButton(),
             const SizedBox(height: 24),
@@ -98,11 +111,8 @@ class _ContentEnhancementScreenState extends State<ContentEnhancementScreen> {
         ),
         const SizedBox(height: 6),
         Text(
-          'Select an operation and enter your content below',
-          style: TextStyle(
-            fontSize: 14,
-            color: Colors.grey.shade600,
-          ),
+          'Pick one of your drafts, then choose how to refine it',
+          style: TextStyle(fontSize: 14, color: Colors.grey.shade600),
         ),
       ],
     );
@@ -166,7 +176,25 @@ class _ContentEnhancementScreenState extends State<ContentEnhancementScreen> {
     );
   }
 
-  Widget _buildInputSection() {
+  Widget _buildCustomizationPanel() {
+    return Observer(
+      builder: (_) {
+        final accent = _operationMeta[_store.selectedOperation]!.color;
+        return CustomizationPanel(
+          operation: _store.selectedOperation,
+          selectedTone: _store.selectedTone,
+          selectedLength: _store.selectedLength,
+          customInstruction: _store.customInstruction,
+          accentColor: accent,
+          onToneChanged: _store.setTone,
+          onLengthChanged: _store.setLength,
+          onInstructionChanged: _store.setCustomInstruction,
+        );
+      },
+    );
+  }
+
+  Widget _buildContentPickerSection() {
     return Container(
       decoration: BoxDecoration(
         color: Colors.white,
@@ -177,13 +205,14 @@ class _ContentEnhancementScreenState extends State<ContentEnhancementScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 14, 16, 0),
+            padding: const EdgeInsets.fromLTRB(16, 14, 16, 6),
             child: Row(
               children: [
-                const Icon(Icons.edit_note, size: 18, color: Color(0xFF64748B)),
+                const Icon(Icons.article_outlined,
+                    size: 18, color: Color(0xFF64748B)),
                 const SizedBox(width: 6),
                 const Text(
-                  'Input Content',
+                  'Pick a post to enhance',
                   style: TextStyle(
                     fontWeight: FontWeight.w600,
                     fontSize: 13,
@@ -193,7 +222,7 @@ class _ContentEnhancementScreenState extends State<ContentEnhancementScreen> {
                 const Spacer(),
                 Observer(
                   builder: (_) => Text(
-                    '${_store.inputText.length} / 10,000',
+                    '${_store.availableContents.length} posts',
                     style: TextStyle(
                       fontSize: 11,
                       color: Colors.grey.shade400,
@@ -203,16 +232,350 @@ class _ContentEnhancementScreenState extends State<ContentEnhancementScreen> {
               ],
             ),
           ),
-          ContentInputWidget(
-            controller: _textController,
-            onClear: () {
-              _store.clearResult();
-              _store.setInputText('');
-            },
-            onChanged: (text) => _store.setInputText(text),
-          ),
+          Observer(builder: (_) => _buildPickerBody()),
         ],
       ),
+    );
+  }
+
+
+  Widget _buildPickerBody() {
+    // Capture observable reads SYNCHRONOUSLY here so MobX subscribes the
+    // surrounding Observer to them. Reads inside ListView.itemBuilder are
+    // lazy and do NOT establish a subscription, which is why the picker
+    // wasn't rebuilding when `selectedContent` changed.
+    final loading = _store.loadingContents;
+    final contents = _store.availableContents.toList();
+    final selectedId = _store.selectedContent?.id;
+
+    if (loading && contents.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 32),
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (contents.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.fromLTRB(16, 4, 16, 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(Icons.inbox_outlined,
+                size: 36, color: Colors.grey.shade300),
+            const SizedBox(height: 8),
+            Text(
+              'No drafts found in your project',
+              style: TextStyle(
+                  color: Colors.grey.shade600, fontWeight: FontWeight.w500),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Generate a post in Content Studio first, then come back to enhance it.',
+              style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
+            ),
+          ],
+        ),
+      );
+    }
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 320),
+      child: ListView.separated(
+        padding: const EdgeInsets.fromLTRB(12, 8, 12, 14),
+        shrinkWrap: true,
+        itemCount: contents.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 10),
+        itemBuilder: (_, idx) {
+          final item = contents[idx];
+          return _buildPickerCard(item, item.id == selectedId);
+        },
+      ),
+    );
+  }
+
+  Widget _buildPickerCard(ContentItem item, bool isSelected) {
+    final accent = _operationMeta[_store.selectedOperation]!.color;
+    final disabled = !item.isEnhanceable;
+
+    // Filled solid color when selected — by far the strongest visual cue.
+    final bgColor = disabled
+        ? Colors.grey.shade50
+        : (isSelected ? accent : Colors.white);
+    final fgColor = disabled
+        ? Colors.grey.shade400
+        : (isSelected ? Colors.white : const Color(0xFF1E293B));
+    final subtleColor = isSelected
+        ? Colors.white.withValues(alpha: 0.85)
+        : Colors.grey.shade500;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: disabled ? null : () => _store.selectContent(item),
+        borderRadius: BorderRadius.circular(12),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOut,
+          padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+          decoration: BoxDecoration(
+            color: bgColor,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: isSelected
+                  ? accent
+                  : (disabled ? Colors.grey.shade200 : Colors.grey.shade300),
+              width: isSelected ? 2 : 1,
+            ),
+            boxShadow: isSelected
+                ? [
+                    BoxShadow(
+                      color: accent.withValues(alpha: 0.35),
+                      blurRadius: 14,
+                      offset: const Offset(0, 4),
+                    ),
+                  ]
+                : null,
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              // Big bold check / empty circle on the left.
+              AnimatedContainer(
+                duration: const Duration(milliseconds: 180),
+                width: 32,
+                height: 32,
+                decoration: BoxDecoration(
+                  color: isSelected
+                      ? Colors.white
+                      : (disabled
+                          ? Colors.grey.shade100
+                          : Colors.grey.shade100),
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: isSelected
+                        ? Colors.white
+                        : Colors.grey.shade300,
+                    width: 1.5,
+                  ),
+                ),
+                child: Icon(
+                  isSelected ? Icons.check_rounded : Icons.add_rounded,
+                  size: 22,
+                  color: isSelected ? accent : Colors.grey.shade400,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            item.title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontWeight: FontWeight.w700,
+                              fontSize: 14,
+                              color: fgColor,
+                            ),
+                          ),
+                        ),
+                        if (isSelected)
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 8, vertical: 3),
+                            decoration: BoxDecoration(
+                              color: Colors.white,
+                              borderRadius: BorderRadius.circular(6),
+                            ),
+                            child: Text(
+                              '✓ SELECTED',
+                              style: TextStyle(
+                                fontSize: 10,
+                                color: accent,
+                                fontWeight: FontWeight.w800,
+                                letterSpacing: 0.4,
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 6),
+                    Row(
+                      children: [
+                        _buildPickerStatusChip(item.status, isSelected),
+                        if (item.contentType.isNotEmpty) ...[
+                          const SizedBox(width: 6),
+                          _buildPickerTypeChip(item.contentType, isSelected),
+                        ],
+                        if (item.topicName.isNotEmpty) ...[
+                          const SizedBox(width: 8),
+                          Flexible(
+                            child: Text(
+                              item.topicName,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                fontSize: 11,
+                                color: subtleColor,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPickerStatusChip(String status, bool isSelected) {
+    if (isSelected) {
+      // White-on-translucent pill so it stays legible against the accent fill.
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.22),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Text(
+          status.toUpperCase(),
+          style: const TextStyle(
+              fontSize: 10,
+              color: Colors.white,
+              fontWeight: FontWeight.w700),
+        ),
+      );
+    }
+    return _buildStatusBadge(status);
+  }
+
+  Widget _buildPickerTypeChip(String type, bool isSelected) {
+    if (isSelected) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.22),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Text(
+          type,
+          style: const TextStyle(
+              fontSize: 10,
+              color: Colors.white,
+              fontWeight: FontWeight.w600),
+        ),
+      );
+    }
+    return _buildTypeBadge(type);
+  }
+
+  Widget _buildStatusBadge(String status) {
+    final s = status.toUpperCase();
+    final color = switch (s) {
+      'PUBLISHED' => const Color(0xFF059669),
+      'READY' || 'COMPLETE' => const Color(0xFF2563EB),
+      'DRAFTING' => const Color(0xFFD97706),
+      'FAILED' => const Color(0xFFDC2626),
+      _ => const Color(0xFF64748B),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        s,
+        style: TextStyle(
+            fontSize: 10, color: color, fontWeight: FontWeight.w700),
+      ),
+    );
+  }
+
+  Widget _buildTypeBadge(String type) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF1F5F9),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        type,
+        style: const TextStyle(
+            fontSize: 10,
+            color: Color(0xFF475569),
+            fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+
+  Widget _buildSelectedPreview() {
+    return Observer(
+      builder: (_) {
+        final picked = _store.selectedContent;
+        if (picked == null) return const SizedBox.shrink();
+        final hasBody = picked.body.isNotEmpty;
+        return Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: Colors.grey.shade200),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(14, 12, 14, 4),
+                child: Row(
+                  children: [
+                    Icon(Icons.preview_outlined,
+                        size: 16, color: Colors.grey.shade600),
+                    const SizedBox(width: 6),
+                    Text(
+                      'Selected draft — ${picked.title}',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Colors.grey.shade600,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 220),
+                child: Scrollbar(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.fromLTRB(14, 4, 14, 14),
+                    child: SelectableText(
+                      hasBody
+                          ? picked.body
+                          : '(This draft has no body yet — pick another or generate it first.)',
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: hasBody
+                            ? const Color(0xFF334155)
+                            : Colors.grey.shade400,
+                        height: 1.5,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 
@@ -220,8 +583,11 @@ class _ContentEnhancementScreenState extends State<ContentEnhancementScreen> {
     return Observer(
       builder: (_) {
         final meta = _operationMeta[_store.selectedOperation]!;
-        final isDisabled =
-            _store.loading || _store.inputText.trim().isEmpty;
+        final picked = _store.selectedContent;
+        final isDisabled = _store.loading ||
+            picked == null ||
+            picked.id.isEmpty ||
+            !picked.isEnhanceable;
         return SizedBox(
           height: 48,
           child: ElevatedButton.icon(
@@ -238,8 +604,10 @@ class _ContentEnhancementScreenState extends State<ContentEnhancementScreen> {
                 : Icon(meta.icon, size: 18),
             label: Text(
               _store.loading
-                  ? 'Processing...'
-                  : _store.selectedOperation.displayName,
+                  ? 'Processing... (this may take ~30s)'
+                  : (picked == null
+                      ? 'Select a post to ${_store.selectedOperation.displayName.toLowerCase()}'
+                      : '${_store.selectedOperation.displayName} this post'),
               style: const TextStyle(
                 fontWeight: FontWeight.w600,
                 fontSize: 15,
@@ -265,6 +633,7 @@ class _ContentEnhancementScreenState extends State<ContentEnhancementScreen> {
       builder: (_) {
         if (_store.success && _store.currentResult != null) {
           final meta = _operationMeta[_store.currentResult!.operation]!;
+          final picked = _store.selectedContent;
           return Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
@@ -272,38 +641,38 @@ class _ContentEnhancementScreenState extends State<ContentEnhancementScreen> {
                 children: [
                   Icon(Icons.check_circle, size: 18, color: meta.color),
                   const SizedBox(width: 6),
-                  Text(
-                    'Result — ${_store.currentResult!.operation.displayName}',
-                    style: const TextStyle(
-                      fontWeight: FontWeight.w600,
-                      fontSize: 15,
-                      color: Color(0xFF1E293B),
+                  Expanded(
+                    child: Text(
+                      'Result — ${_store.currentResult!.operation.displayName}',
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 15,
+                        color: Color(0xFF1E293B),
+                      ),
                     ),
                   ),
+                  if (_store.currentResult!.tokensUsed != null)
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 8, vertical: 3),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFF1F5F9),
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Text(
+                        '${_store.currentResult!.tokensUsed} tokens',
+                        style: const TextStyle(
+                            fontSize: 11, color: Color(0xFF64748B)),
+                      ),
+                    ),
                 ],
               ),
               const SizedBox(height: 10),
-              ContentResultWidget(
-                result: _store.currentResult,
-                onCopy: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: const Row(
-                        children: [
-                          Icon(Icons.check, color: Colors.white, size: 16),
-                          SizedBox(width: 8),
-                          Text('Copied to clipboard'),
-                        ],
-                      ),
-                      backgroundColor: const Color(0xFF059669),
-                      behavior: SnackBarBehavior.floating,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      duration: const Duration(seconds: 2),
-                    ),
-                  );
-                },
+              BeforeAfterWidget(
+                originalBody: picked?.body ?? '',
+                resultBody: _store.currentResult!.resultText,
+                accentColor: meta.color,
+                onCopyResult: () => _showCopiedToast(),
               ),
             ],
           );
@@ -325,15 +694,32 @@ class _ContentEnhancementScreenState extends State<ContentEnhancementScreen> {
               const SizedBox(height: 10),
               Text(
                 'Result will appear here',
-                style: TextStyle(
-                  color: Colors.grey.shade400,
-                  fontSize: 14,
-                ),
+                style: TextStyle(color: Colors.grey.shade400, fontSize: 14),
               ),
             ],
           ),
         );
       },
+    );
+  }
+
+  void _showCopiedToast() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: const Row(
+          children: [
+            Icon(Icons.check, color: Colors.white, size: 16),
+            SizedBox(width: 8),
+            Text('Copied to clipboard'),
+          ],
+        ),
+        backgroundColor: const Color(0xFF059669),
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+        ),
+        duration: const Duration(seconds: 2),
+      ),
     );
   }
 }

--- a/lib/presentation/content_enhancement/store/content_enhancement_store.dart
+++ b/lib/presentation/content_enhancement/store/content_enhancement_store.dart
@@ -1,4 +1,8 @@
+import 'dart:async';
+
 import 'package:boilerplate/core/stores/error/error_store.dart';
+import 'package:boilerplate/data/network/apis/content/content_api.dart';
+import 'package:boilerplate/domain/entity/content/content_item.dart';
 import 'package:boilerplate/domain/entity/content/content_operation.dart';
 import 'package:boilerplate/domain/entity/content/content_request.dart';
 import 'package:boilerplate/domain/entity/content/content_result.dart';
@@ -20,27 +24,62 @@ abstract class _ContentEnhancementStore with Store {
   final RewriteContentUseCase _rewriteUseCase;
   final HumanizeContentUseCase _humanizeUseCase;
   final SummarizeContentUseCase _summarizeUseCase;
+  final ContentApi _contentApi;
   final ErrorStore errorStore;
+
+  static const Duration _pollInterval = Duration(seconds: 3);
+  static const int _maxPollAttempts = 60; // ~3 min total
 
   _ContentEnhancementStore(
     this._enhanceUseCase,
     this._rewriteUseCase,
     this._humanizeUseCase,
     this._summarizeUseCase,
+    this._contentApi,
     this.errorStore,
   );
+
+  // ─── Picker state ────────────────────────────────────────────────────────
+
+  @observable
+  ObservableList<ContentItem> availableContents =
+      ObservableList<ContentItem>();
+
+  @observable
+  ContentItem? selectedContent;
+
+  @observable
+  bool loadingContents = false;
+
+  @observable
+  String? activeProjectId;
+
+  // ─── Operation state ─────────────────────────────────────────────────────
 
   @observable
   ContentOperation selectedOperation = ContentOperation.enhance;
 
+  /// One of: professional, casual, friendly, formal, playful (or null = no tone hint).
+  /// Sent as `tone` in the request body — applies to enhance / rewrite / humanize.
   @observable
-  String inputText = '';
+  String? selectedTone;
+
+  /// One of: short, medium, long. Only used when [selectedOperation] is summarize.
+  @observable
+  String selectedLength = 'medium';
+
+  /// Optional free-text instruction the user can append to the operation
+  /// preset. Maps to `customInstruction` on the BE DTO and is appended to
+  /// the regenerate `improvement` prompt.
+  @observable
+  String customInstruction = '';
 
   @observable
   ContentResult? currentResult;
 
   @observable
-  ObservableList<ContentResult> sessionHistory = ObservableList<ContentResult>();
+  ObservableList<ContentResult> sessionHistory =
+      ObservableList<ContentResult>();
 
   @observable
   bool loading = false;
@@ -48,56 +87,179 @@ abstract class _ContentEnhancementStore with Store {
   @observable
   bool success = false;
 
+  @observable
+  String? activeJobId;
+
+  Timer? _pollTimer;
+  int _pollAttempts = 0;
+
+  // ─── Picker actions ──────────────────────────────────────────────────────
+
+  /// Load the user's first project + its contents. Called from screen init.
+  /// If projects list is empty (new account), [availableContents] stays empty
+  /// and the UI shows an empty-state hint.
+  @action
+  Future<void> loadAvailableContents({bool force = false}) async {
+    if (loadingContents) return;
+    if (!force && availableContents.isNotEmpty) return;
+
+    loadingContents = true;
+    try {
+      final projects = await _contentApi.listProjects();
+      if (projects.isEmpty) {
+        availableContents = ObservableList<ContentItem>();
+        return;
+      }
+      final projectId = projects.first['id']?.toString() ?? '';
+      if (projectId.isEmpty) return;
+      activeProjectId = projectId;
+
+      final items = await _contentApi.listProjectContents(projectId);
+      availableContents = ObservableList<ContentItem>.of(items);
+    } catch (e) {
+      _surfaceError(e);
+    } finally {
+      loadingContents = false;
+    }
+  }
+
+  @action
+  void selectContent(ContentItem item) {
+    selectedContent = item;
+    // Reset previous result so the user sees a clean preview.
+    currentResult = null;
+    success = false;
+  }
+
+  @action
+  void clearSelection() {
+    selectedContent = null;
+    currentResult = null;
+    success = false;
+    _cancelPolling();
+  }
+
+  // ─── Operation actions ───────────────────────────────────────────────────
+
   @action
   void setOperation(ContentOperation operation) {
     selectedOperation = operation;
   }
 
   @action
-  void setInputText(String text) {
-    inputText = text;
+  void setTone(String? tone) {
+    selectedTone = tone;
+  }
+
+  @action
+  void setLength(String length) {
+    selectedLength = length;
+  }
+
+  @action
+  void setCustomInstruction(String value) {
+    customInstruction = value;
+  }
+
+  /// Build the body options for the API call from the current state.
+  Map<String, dynamic>? _buildOptions() {
+    final options = <String, dynamic>{};
+    final isSummarize = selectedOperation == ContentOperation.summarize;
+    if (!isSummarize && selectedTone != null && selectedTone!.isNotEmpty) {
+      options['tone'] = selectedTone;
+    }
+    if (isSummarize) {
+      options['length'] = selectedLength;
+    }
+    final trimmed = customInstruction.trim();
+    if (trimmed.isNotEmpty) {
+      options['customInstruction'] = trimmed;
+    }
+    return options.isEmpty ? null : options;
   }
 
   @action
   Future<void> processContent() async {
-    if (inputText.trim().isEmpty) return;
+    final picked = selectedContent;
+    if (picked == null || picked.id.isEmpty) return;
 
+    _cancelPolling();
     loading = true;
     success = false;
+    currentResult = null;
 
     try {
       final request = ContentRequest(
-        text: inputText,
+        contentId: picked.id,
         operation: selectedOperation,
+        options: _buildOptions(),
       );
 
-      ContentResult result;
+      final ContentResult ack;
       switch (selectedOperation) {
         case ContentOperation.enhance:
-          result = await _enhanceUseCase.call(params: request);
+          ack = await _enhanceUseCase.call(params: request);
           break;
         case ContentOperation.rewrite:
-          result = await _rewriteUseCase.call(params: request);
+          ack = await _rewriteUseCase.call(params: request);
           break;
         case ContentOperation.humanize:
-          result = await _humanizeUseCase.call(params: request);
+          ack = await _humanizeUseCase.call(params: request);
           break;
         case ContentOperation.summarize:
-          result = await _summarizeUseCase.call(params: request);
+          ack = await _summarizeUseCase.call(params: request);
           break;
       }
 
-      currentResult = result;
-      sessionHistory.add(result);
-      success = true;
+      activeJobId = ack.jobId;
+      currentResult = ack;
+      _startPolling(ack.jobId);
     } catch (e) {
-      if (e is DioException) {
-        errorStore.errorMessage = DioExceptionUtil.handleError(e);
-      } else {
-        errorStore.errorMessage = e.toString();
-      }
-    } finally {
       loading = false;
+      _surfaceError(e);
+    }
+  }
+
+  void _startPolling(String jobId) {
+    _pollAttempts = 0;
+    _pollTimer = Timer.periodic(_pollInterval, (_) => _pollOnce(jobId));
+  }
+
+  Future<void> _pollOnce(String jobId) async {
+    _pollAttempts++;
+    if (_pollAttempts > _maxPollAttempts) {
+      _cancelPolling();
+      loading = false;
+      errorStore.errorMessage =
+          'Enhancement timed out after ${_maxPollAttempts * _pollInterval.inSeconds}s';
+      return;
+    }
+
+    try {
+      final result = await _contentApi.pollByJob(jobId);
+      if (result == null) return; // still running
+      _cancelPolling();
+      currentResult = result.copyWith(operation: selectedOperation);
+      sessionHistory.add(currentResult!);
+      success = true;
+      loading = false;
+    } catch (e) {
+      _cancelPolling();
+      loading = false;
+      _surfaceError(e);
+    }
+  }
+
+  void _cancelPolling() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+  }
+
+  void _surfaceError(Object e) {
+    if (e is DioException) {
+      errorStore.errorMessage = DioExceptionUtil.handleError(e);
+    } else {
+      errorStore.errorMessage = e.toString();
     }
   }
 
@@ -105,6 +267,8 @@ abstract class _ContentEnhancementStore with Store {
   void clearResult() {
     currentResult = null;
     success = false;
+    activeJobId = null;
+    _cancelPolling();
   }
 
   @action

--- a/lib/presentation/content_enhancement/store/content_enhancement_store.g.dart
+++ b/lib/presentation/content_enhancement/store/content_enhancement_store.g.dart
@@ -9,6 +9,70 @@ part of 'content_enhancement_store.dart';
 // ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic, no_leading_underscores_for_local_identifiers
 
 mixin _$ContentEnhancementStore on _ContentEnhancementStore, Store {
+  late final _$availableContentsAtom = Atom(
+      name: '_ContentEnhancementStore.availableContents', context: context);
+
+  @override
+  ObservableList<ContentItem> get availableContents {
+    _$availableContentsAtom.reportRead();
+    return super.availableContents;
+  }
+
+  @override
+  set availableContents(ObservableList<ContentItem> value) {
+    _$availableContentsAtom.reportWrite(value, super.availableContents, () {
+      super.availableContents = value;
+    });
+  }
+
+  late final _$selectedContentAtom =
+      Atom(name: '_ContentEnhancementStore.selectedContent', context: context);
+
+  @override
+  ContentItem? get selectedContent {
+    _$selectedContentAtom.reportRead();
+    return super.selectedContent;
+  }
+
+  @override
+  set selectedContent(ContentItem? value) {
+    _$selectedContentAtom.reportWrite(value, super.selectedContent, () {
+      super.selectedContent = value;
+    });
+  }
+
+  late final _$loadingContentsAtom =
+      Atom(name: '_ContentEnhancementStore.loadingContents', context: context);
+
+  @override
+  bool get loadingContents {
+    _$loadingContentsAtom.reportRead();
+    return super.loadingContents;
+  }
+
+  @override
+  set loadingContents(bool value) {
+    _$loadingContentsAtom.reportWrite(value, super.loadingContents, () {
+      super.loadingContents = value;
+    });
+  }
+
+  late final _$activeProjectIdAtom =
+      Atom(name: '_ContentEnhancementStore.activeProjectId', context: context);
+
+  @override
+  String? get activeProjectId {
+    _$activeProjectIdAtom.reportRead();
+    return super.activeProjectId;
+  }
+
+  @override
+  set activeProjectId(String? value) {
+    _$activeProjectIdAtom.reportWrite(value, super.activeProjectId, () {
+      super.activeProjectId = value;
+    });
+  }
+
   late final _$selectedOperationAtom = Atom(
       name: '_ContentEnhancementStore.selectedOperation', context: context);
 
@@ -25,19 +89,51 @@ mixin _$ContentEnhancementStore on _ContentEnhancementStore, Store {
     });
   }
 
-  late final _$inputTextAtom =
-      Atom(name: '_ContentEnhancementStore.inputText', context: context);
+  late final _$selectedToneAtom =
+      Atom(name: '_ContentEnhancementStore.selectedTone', context: context);
 
   @override
-  String get inputText {
-    _$inputTextAtom.reportRead();
-    return super.inputText;
+  String? get selectedTone {
+    _$selectedToneAtom.reportRead();
+    return super.selectedTone;
   }
 
   @override
-  set inputText(String value) {
-    _$inputTextAtom.reportWrite(value, super.inputText, () {
-      super.inputText = value;
+  set selectedTone(String? value) {
+    _$selectedToneAtom.reportWrite(value, super.selectedTone, () {
+      super.selectedTone = value;
+    });
+  }
+
+  late final _$selectedLengthAtom =
+      Atom(name: '_ContentEnhancementStore.selectedLength', context: context);
+
+  @override
+  String get selectedLength {
+    _$selectedLengthAtom.reportRead();
+    return super.selectedLength;
+  }
+
+  @override
+  set selectedLength(String value) {
+    _$selectedLengthAtom.reportWrite(value, super.selectedLength, () {
+      super.selectedLength = value;
+    });
+  }
+
+  late final _$customInstructionAtom = Atom(
+      name: '_ContentEnhancementStore.customInstruction', context: context);
+
+  @override
+  String get customInstruction {
+    _$customInstructionAtom.reportRead();
+    return super.customInstruction;
+  }
+
+  @override
+  set customInstruction(String value) {
+    _$customInstructionAtom.reportWrite(value, super.customInstruction, () {
+      super.customInstruction = value;
     });
   }
 
@@ -105,6 +201,32 @@ mixin _$ContentEnhancementStore on _ContentEnhancementStore, Store {
     });
   }
 
+  late final _$activeJobIdAtom =
+      Atom(name: '_ContentEnhancementStore.activeJobId', context: context);
+
+  @override
+  String? get activeJobId {
+    _$activeJobIdAtom.reportRead();
+    return super.activeJobId;
+  }
+
+  @override
+  set activeJobId(String? value) {
+    _$activeJobIdAtom.reportWrite(value, super.activeJobId, () {
+      super.activeJobId = value;
+    });
+  }
+
+  late final _$loadAvailableContentsAsyncAction = AsyncAction(
+      '_ContentEnhancementStore.loadAvailableContents',
+      context: context);
+
+  @override
+  Future<void> loadAvailableContents({bool force = false}) {
+    return _$loadAvailableContentsAsyncAction
+        .run(() => super.loadAvailableContents(force: force));
+  }
+
   late final _$processContentAsyncAction =
       AsyncAction('_ContentEnhancementStore.processContent', context: context);
 
@@ -115,6 +237,28 @@ mixin _$ContentEnhancementStore on _ContentEnhancementStore, Store {
 
   late final _$_ContentEnhancementStoreActionController =
       ActionController(name: '_ContentEnhancementStore', context: context);
+
+  @override
+  void selectContent(ContentItem item) {
+    final _$actionInfo = _$_ContentEnhancementStoreActionController.startAction(
+        name: '_ContentEnhancementStore.selectContent');
+    try {
+      return super.selectContent(item);
+    } finally {
+      _$_ContentEnhancementStoreActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  void clearSelection() {
+    final _$actionInfo = _$_ContentEnhancementStoreActionController.startAction(
+        name: '_ContentEnhancementStore.clearSelection');
+    try {
+      return super.clearSelection();
+    } finally {
+      _$_ContentEnhancementStoreActionController.endAction(_$actionInfo);
+    }
+  }
 
   @override
   void setOperation(ContentOperation operation) {
@@ -128,11 +272,33 @@ mixin _$ContentEnhancementStore on _ContentEnhancementStore, Store {
   }
 
   @override
-  void setInputText(String text) {
+  void setTone(String? tone) {
     final _$actionInfo = _$_ContentEnhancementStoreActionController.startAction(
-        name: '_ContentEnhancementStore.setInputText');
+        name: '_ContentEnhancementStore.setTone');
     try {
-      return super.setInputText(text);
+      return super.setTone(tone);
+    } finally {
+      _$_ContentEnhancementStoreActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  void setLength(String length) {
+    final _$actionInfo = _$_ContentEnhancementStoreActionController.startAction(
+        name: '_ContentEnhancementStore.setLength');
+    try {
+      return super.setLength(length);
+    } finally {
+      _$_ContentEnhancementStoreActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  void setCustomInstruction(String value) {
+    final _$actionInfo = _$_ContentEnhancementStoreActionController.startAction(
+        name: '_ContentEnhancementStore.setCustomInstruction');
+    try {
+      return super.setCustomInstruction(value);
     } finally {
       _$_ContentEnhancementStoreActionController.endAction(_$actionInfo);
     }
@@ -163,12 +329,19 @@ mixin _$ContentEnhancementStore on _ContentEnhancementStore, Store {
   @override
   String toString() {
     return '''
+availableContents: ${availableContents},
+selectedContent: ${selectedContent},
+loadingContents: ${loadingContents},
+activeProjectId: ${activeProjectId},
 selectedOperation: ${selectedOperation},
-inputText: ${inputText},
+selectedTone: ${selectedTone},
+selectedLength: ${selectedLength},
+customInstruction: ${customInstruction},
 currentResult: ${currentResult},
 sessionHistory: ${sessionHistory},
 loading: ${loading},
-success: ${success}
+success: ${success},
+activeJobId: ${activeJobId}
     ''';
   }
 }

--- a/lib/presentation/content_enhancement/widgets/before_after_widget.dart
+++ b/lib/presentation/content_enhancement/widgets/before_after_widget.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Side-by-side comparison of the original draft body and the AI result.
+///
+/// Falls back to a stacked layout when the available width is too narrow
+/// for two columns (~600 px breakpoint), so this widget works on both
+/// phone and tablet/web shells.
+class BeforeAfterWidget extends StatelessWidget {
+  final String originalBody;
+  final String resultBody;
+  final Color accentColor;
+  final VoidCallback? onCopyResult;
+
+  const BeforeAfterWidget({
+    Key? key,
+    required this.originalBody,
+    required this.resultBody,
+    required this.accentColor,
+    this.onCopyResult,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final useColumns = constraints.maxWidth >= 600;
+        final originalPanel = _buildPanel(
+          title: 'Original',
+          icon: Icons.article_outlined,
+          color: const Color(0xFF94A3B8),
+          body: originalBody,
+        );
+        final resultPanel = _buildPanel(
+          title: 'AI Result',
+          icon: Icons.auto_fix_high,
+          color: accentColor,
+          body: resultBody,
+          actions: [
+            TextButton.icon(
+              onPressed: () {
+                Clipboard.setData(ClipboardData(text: resultBody));
+                onCopyResult?.call();
+              },
+              icon: const Icon(Icons.copy, size: 14),
+              label: const Text('Copy', style: TextStyle(fontSize: 12)),
+              style: TextButton.styleFrom(
+                foregroundColor: accentColor,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                minimumSize: Size.zero,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+            ),
+          ],
+        );
+
+        if (useColumns) {
+          return IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(child: originalPanel),
+                const SizedBox(width: 12),
+                Expanded(child: resultPanel),
+              ],
+            ),
+          );
+        }
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            originalPanel,
+            const SizedBox(height: 12),
+            resultPanel,
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildPanel({
+    required String title,
+    required IconData icon,
+    required Color color,
+    required String body,
+    List<Widget> actions = const [],
+  }) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey.shade200),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Container(
+            padding: const EdgeInsets.fromLTRB(14, 10, 8, 10),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.06),
+              borderRadius:
+                  const BorderRadius.vertical(top: Radius.circular(12)),
+              border: Border(
+                bottom: BorderSide(color: Colors.grey.shade200),
+              ),
+            ),
+            child: Row(
+              children: [
+                Icon(icon, size: 16, color: color),
+                const SizedBox(width: 6),
+                Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: color,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0.3,
+                  ),
+                ),
+                const Spacer(),
+                ...actions,
+              ],
+            ),
+          ),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 360, minHeight: 80),
+            child: Scrollbar(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(14, 12, 14, 14),
+                child: SelectableText(
+                  body.isEmpty ? '(empty)' : body,
+                  style: TextStyle(
+                    fontSize: 13,
+                    height: 1.55,
+                    color: body.isEmpty
+                        ? Colors.grey.shade400
+                        : const Color(0xFF334155),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/content_enhancement/widgets/content_input_widget.dart
+++ b/lib/presentation/content_enhancement/widgets/content_input_widget.dart
@@ -16,12 +16,12 @@ class ContentInputWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return TextField(
       controller: controller,
-      maxLines: 8,
-      maxLength: 10000,
+      maxLines: 1,
+      maxLength: 64,
       onChanged: onChanged,
       style: const TextStyle(fontSize: 14, height: 1.5),
       decoration: InputDecoration(
-        hintText: 'Paste or type your content here...',
+        hintText: 'Paste the draft content ID (UUID) here',
         hintStyle: TextStyle(color: Colors.grey.shade400, fontSize: 14),
         border: InputBorder.none,
         counterText: '',

--- a/lib/presentation/content_enhancement/widgets/customization_panel.dart
+++ b/lib/presentation/content_enhancement/widgets/customization_panel.dart
@@ -1,0 +1,218 @@
+import 'package:boilerplate/domain/entity/content/content_operation.dart';
+import 'package:flutter/material.dart';
+
+/// Shows the user-controllable knobs for an enhancement run:
+///   * Free-text "describe what to change" input (always visible).
+///   * Tone chips — visible for enhance / rewrite / humanize.
+///   * Length chips — visible only when the chosen operation is summarize.
+///
+/// All callbacks are required: the parent (store) owns state.
+class CustomizationPanel extends StatelessWidget {
+  final ContentOperation operation;
+  final String? selectedTone;
+  final String selectedLength;
+  final String customInstruction;
+  final Color accentColor;
+  final ValueChanged<String?> onToneChanged;
+  final ValueChanged<String> onLengthChanged;
+  final ValueChanged<String> onInstructionChanged;
+
+  const CustomizationPanel({
+    Key? key,
+    required this.operation,
+    required this.selectedTone,
+    required this.selectedLength,
+    required this.customInstruction,
+    required this.accentColor,
+    required this.onToneChanged,
+    required this.onLengthChanged,
+    required this.onInstructionChanged,
+  }) : super(key: key);
+
+  static const _tones = <_Option>[
+    _Option('professional', 'Professional', Icons.business_center_outlined),
+    _Option('casual', 'Casual', Icons.weekend_outlined),
+    _Option('friendly', 'Friendly', Icons.sentiment_satisfied),
+    _Option('formal', 'Formal', Icons.school_outlined),
+    _Option('playful', 'Playful', Icons.celebration_outlined),
+  ];
+
+  static const _lengths = <_Option>[
+    _Option('short', 'Short', Icons.short_text),
+    _Option('medium', 'Medium', Icons.notes),
+    _Option('long', 'Long', Icons.subject),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final isSummarize = operation == ContentOperation.summarize;
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey.shade200),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.tune, size: 18, color: Color(0xFF64748B)),
+              const SizedBox(width: 6),
+              const Text(
+                'Customize the AI output',
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  fontSize: 13,
+                  color: Color(0xFF475569),
+                ),
+              ),
+              const Spacer(),
+              Text(
+                'Optional',
+                style: TextStyle(fontSize: 11, color: Colors.grey.shade400),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          _buildLabel('Tell the AI what to focus on', Icons.edit_note_outlined),
+          const SizedBox(height: 6),
+          _buildInstructionField(),
+          const SizedBox(height: 14),
+          if (!isSummarize) ...[
+            _buildLabel('Target tone', Icons.record_voice_over_outlined),
+            const SizedBox(height: 8),
+            _buildChipRow(
+              options: _tones,
+              selected: selectedTone,
+              onSelected: (value) {
+                onToneChanged(selectedTone == value ? null : value);
+              },
+            ),
+          ] else ...[
+            _buildLabel('Summary length', Icons.text_decrease_outlined),
+            const SizedBox(height: 8),
+            _buildChipRow(
+              options: _lengths,
+              selected: selectedLength,
+              onSelected: (value) => onLengthChanged(value),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLabel(String text, IconData icon) {
+    return Row(
+      children: [
+        Icon(icon, size: 14, color: Colors.grey.shade500),
+        const SizedBox(width: 4),
+        Text(
+          text,
+          style: TextStyle(
+            fontSize: 12,
+            color: Colors.grey.shade600,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildInstructionField() {
+    return TextField(
+      onChanged: onInstructionChanged,
+      controller: TextEditingController(text: customInstruction)
+        ..selection = TextSelection.collapsed(offset: customInstruction.length),
+      maxLines: 3,
+      maxLength: 500,
+      style: const TextStyle(fontSize: 13, height: 1.4),
+      decoration: InputDecoration(
+        hintText:
+            'e.g. "Keep brand mentions intact and target a Vietnamese audience"',
+        hintStyle: TextStyle(fontSize: 13, color: Colors.grey.shade400),
+        filled: true,
+        fillColor: const Color(0xFFF8FAFC),
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: Colors.grey.shade200),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: Colors.grey.shade200),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: accentColor.withValues(alpha: 0.6)),
+        ),
+        counterStyle: TextStyle(fontSize: 10, color: Colors.grey.shade400),
+      ),
+    );
+  }
+
+  Widget _buildChipRow({
+    required List<_Option> options,
+    required String? selected,
+    required ValueChanged<String> onSelected,
+  }) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: options.map((opt) {
+        final isSelected = selected == opt.value;
+        return InkWell(
+          onTap: () => onSelected(opt.value),
+          borderRadius: BorderRadius.circular(20),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
+            padding:
+                const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            decoration: BoxDecoration(
+              color: isSelected
+                  ? accentColor.withValues(alpha: 0.1)
+                  : const Color(0xFFF8FAFC),
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(
+                color: isSelected ? accentColor : Colors.grey.shade200,
+                width: isSelected ? 1.5 : 1,
+              ),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  opt.icon,
+                  size: 14,
+                  color: isSelected ? accentColor : Colors.grey.shade500,
+                ),
+                const SizedBox(width: 5),
+                Text(
+                  opt.label,
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: isSelected
+                        ? accentColor
+                        : const Color(0xFF334155),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+class _Option {
+  final String value;
+  final String label;
+  final IconData icon;
+  const _Option(this.value, this.label, this.icon);
+}

--- a/lib/presentation/di/module/store_module.dart
+++ b/lib/presentation/di/module/store_module.dart
@@ -27,6 +27,7 @@ import 'package:boilerplate/domain/usecase/cronjob/update_cronjob_usecase.dart';
 import 'package:boilerplate/domain/usecase/cronjob/delete_cronjob_usecase.dart';
 import 'package:boilerplate/domain/usecase/cronjob/get_cronjob_executions_usecase.dart';
 import 'package:boilerplate/domain/usecase/cronjob/create_execution_usecase.dart';
+import 'package:boilerplate/data/network/apis/content/content_api.dart';
 import 'package:boilerplate/data/service/mock_execution_service.dart';
 import 'package:boilerplate/presentation/login/store/login_store.dart';
 import 'package:boilerplate/presentation/post/store/post_store.dart';
@@ -105,6 +106,7 @@ class StoreModule {
         getIt<RewriteContentUseCase>(),
         getIt<HumanizeContentUseCase>(),
         getIt<SummarizeContentUseCase>(),
+        getIt<ContentApi>(),
         getIt<ErrorStore>(),
       ),
     );

--- a/test/domain/entity/content_entity_test.dart
+++ b/test/domain/entity/content_entity_test.dart
@@ -21,13 +21,17 @@ void main() {
   });
 
   group('ContentRequest', () {
+    // The BE reuses the regenerate N8N flow, so the body only needs
+    // optional tone/length hints — operation is in the URL, contentId
+    // identifies the target draft.
+
     test('constructor sets all fields correctly', () {
       final request = ContentRequest(
-        text: 'Hello world',
+        contentId: 'd6b1aef8-0748-4a32-a2c9-b42f13c6253c',
         operation: ContentOperation.enhance,
       );
 
-      expect(request.text, 'Hello world');
+      expect(request.contentId, 'd6b1aef8-0748-4a32-a2c9-b42f13c6253c');
       expect(request.operation, ContentOperation.enhance);
       expect(request.options, null);
     });
@@ -35,29 +39,27 @@ void main() {
     test('constructor with options', () {
       final options = {'tone': 'formal', 'length': 'short'};
       final request = ContentRequest(
-        text: 'Test text',
+        contentId: 'cid-1',
         operation: ContentOperation.rewrite,
         options: options,
       );
 
-      expect(request.text, 'Test text');
+      expect(request.contentId, 'cid-1');
       expect(request.operation, ContentOperation.rewrite);
       expect(request.options, options);
     });
 
-    // Operation lives in the URL path now (`/api/contents/<op>`), not the
-    // request body. Options are flattened so optional hints (tone, length)
-    // map directly to BE DTO fields.
-
-    test('toMap converts request without options to map', () {
+    test('toMap is empty when no options are provided', () {
       final request = ContentRequest(
-        text: 'Sample text',
+        contentId: 'cid-2',
         operation: ContentOperation.humanize,
       );
 
       final map = request.toMap();
 
-      expect(map['text'], 'Sample text');
+      expect(map.isEmpty, true);
+      expect(map.containsKey('text'), false);
+      expect(map.containsKey('contentId'), false);
       expect(map.containsKey('operation'), false);
       expect(map.containsKey('options'), false);
     });
@@ -65,222 +67,98 @@ void main() {
     test('toMap flattens options into the body', () {
       final options = {'tone': 'formal', 'length': 'short'};
       final request = ContentRequest(
-        text: 'Complex text',
+        contentId: 'cid-3',
         operation: ContentOperation.summarize,
         options: options,
       );
 
       final map = request.toMap();
 
-      expect(map['text'], 'Complex text');
       expect(map['tone'], 'formal');
       expect(map['length'], 'short');
       expect(map.containsKey('options'), false);
       expect(map.containsKey('operation'), false);
+      expect(map.containsKey('contentId'), false);
     });
 
-    test('toMap omits operation key for every operation type', () {
-      final operations = [
-        ContentOperation.enhance,
-        ContentOperation.rewrite,
-        ContentOperation.humanize,
-        ContentOperation.summarize,
-      ];
-
-      for (final op in operations) {
-        final request = ContentRequest(text: 'text', operation: op);
+    test('toMap omits operation + contentId for every operation type', () {
+      for (final op in ContentOperation.values) {
+        final request =
+            ContentRequest(contentId: 'cid-$op', operation: op);
         final map = request.toMap();
         expect(map.containsKey('operation'), false,
             reason: 'operation $op should not appear in body');
-        expect(map['text'], 'text');
+        expect(map.containsKey('contentId'), false);
       }
     });
   });
 
   group('ContentResult', () {
-    test('constructor sets all fields correctly', () {
-      final now = DateTime.now();
-      final result = ContentResult(
-        resultText: 'Enhanced text',
+    test('jobCreated factory builds an ack-only result', () {
+      final result = ContentResult.jobCreated(
+        jobId: 'job-1',
         operation: ContentOperation.enhance,
-        tokensUsed: 50,
-        processedAt: now,
       );
 
-      expect(result.resultText, 'Enhanced text');
+      expect(result.jobId, 'job-1');
       expect(result.operation, ContentOperation.enhance);
-      expect(result.tokensUsed, 50);
-      expect(result.processedAt, now);
-    });
-
-    test('constructor without tokensUsed', () {
-      final now = DateTime.now();
-      final result = ContentResult(
-        resultText: 'Result',
-        operation: ContentOperation.rewrite,
-        processedAt: now,
-      );
-
-      expect(result.resultText, 'Result');
+      expect(result.resultText, '');
       expect(result.tokensUsed, null);
     });
 
-    test('fromMap parses resultText field', () {
+    test('fromMap parses BE content row shape (body field)', () {
       final map = {
-        'result_text': 'Parsed result',
-        'operation': 'enhance',
-        'tokens_used': 100,
-        'processed_at': '2024-01-15T10:00:00.000Z',
-      };
-
-      final result = ContentResult.fromMap(map);
-
-      expect(result.resultText, 'Parsed result');
-    });
-
-    test('fromMap handles resultText without underscore', () {
-      final map = {
-        'resultText': 'Parsed result',
+        'jobId': 'job-2',
         'operation': 'rewrite',
+        'body': 'Regenerated body text',
+        'updatedAt': '2024-01-15T10:00:00.000Z',
       };
 
       final result = ContentResult.fromMap(map);
 
-      expect(result.resultText, 'Parsed result');
+      expect(result.jobId, 'job-2');
+      expect(result.operation, ContentOperation.rewrite);
+      expect(result.resultText, 'Regenerated body text');
+      expect(result.processedAt.year, 2024);
     });
 
-    test('fromMap defaults to empty string when result_text missing', () {
+    test('fromMap accepts result_text fallback', () {
       final map = {
+        'jobId': 'job-3',
         'operation': 'humanize',
-        'processed_at': '2024-01-15T10:00:00.000Z',
+        'result_text': 'Humanized output',
       };
 
       final result = ContentResult.fromMap(map);
 
-      expect(result.resultText, '');
-    });
-
-    test('fromMap parses operation correctly', () {
-      final operations = ['enhance', 'rewrite', 'humanize', 'summarize'];
-
-      for (final opStr in operations) {
-        final map = {
-          'result_text': 'text',
-          'operation': opStr,
-        };
-
-        final result = ContentResult.fromMap(map);
-
-        expect(
-          result.operation.apiPath,
-          opStr,
-          reason: 'Operation $opStr should parse correctly',
-        );
-      }
+      expect(result.resultText, 'Humanized output');
+      expect(result.operation, ContentOperation.humanize);
     });
 
     test('fromMap defaults to enhance for unknown operation', () {
-      final map = {
-        'result_text': 'text',
-        'operation': 'unknown_operation',
-      };
+      final map = {'jobId': 'j', 'operation': 'unknown_op', 'body': 'x'};
 
-      final result = ContentResult.fromMap(map);
-
-      expect(result.operation, ContentOperation.enhance);
+      expect(ContentResult.fromMap(map).operation, ContentOperation.enhance);
     });
 
-    test('fromMap defaults to enhance when operation missing', () {
-      final map = {'result_text': 'text'};
+    test('fromMap keeps empty resultText when body missing', () {
+      final map = {'jobId': 'j', 'operation': 'summarize'};
 
-      final result = ContentResult.fromMap(map);
-
-      expect(result.operation, ContentOperation.enhance);
+      expect(ContentResult.fromMap(map).resultText, '');
     });
 
-    test('fromMap parses tokensUsed correctly', () {
-      final map = {
-        'result_text': 'text',
-        'operation': 'enhance',
-        'tokens_used': 250,
-      };
-
-      final result = ContentResult.fromMap(map);
-
-      expect(result.tokensUsed, 250);
-    });
-
-    test('fromMap handles missing tokensUsed', () {
-      final map = {
-        'result_text': 'text',
-        'operation': 'rewrite',
-      };
-
-      final result = ContentResult.fromMap(map);
-
-      expect(result.tokensUsed, null);
-    });
-
-    test('fromMap parses ISO8601 datetime string', () {
-      final dateStr = '2024-01-15T10:30:45.000Z';
-      final map = {
-        'result_text': 'text',
-        'operation': 'humanize',
-        'processed_at': dateStr,
-      };
-
-      final result = ContentResult.fromMap(map);
-
-      expect(result.processedAt.year, 2024);
-      expect(result.processedAt.month, 1);
-      expect(result.processedAt.day, 15);
-    });
-
-    test('fromMap uses current time when processed_at missing', () {
-      final beforeTime = DateTime.now();
-      final map = {
-        'result_text': 'text',
-        'operation': 'summarize',
-      };
-
-      final result = ContentResult.fromMap(map);
-      final afterTime = DateTime.now();
-
-      expect(
-        result.processedAt.isAfter(beforeTime.subtract(Duration(seconds: 1))),
-        true,
-      );
-      expect(
-        result.processedAt.isBefore(afterTime.add(Duration(seconds: 1))),
-        true,
-      );
-    });
-
-    test('fromMap round-trip with full data', () {
-      final now = DateTime.now();
-      final original = ContentResult(
-        resultText: 'Full result',
+    test('copyWith only overrides supplied fields', () {
+      final base = ContentResult.jobCreated(
+        jobId: 'j',
         operation: ContentOperation.enhance,
-        tokensUsed: 150,
-        processedAt: now,
       );
 
-      final map = {
-        'result_text': original.resultText,
-        'operation': original.operation.apiPath,
-        'tokens_used': original.tokensUsed,
-        'processed_at': original.processedAt.toIso8601String(),
-      };
+      final updated = base.copyWith(resultText: 'final', tokensUsed: 42);
 
-      final result = ContentResult.fromMap(map);
-
-      expect(result.resultText, original.resultText);
-      expect(result.operation, original.operation);
-      expect(result.tokensUsed, original.tokensUsed);
-      expect(
-        result.processedAt.difference(original.processedAt).inMilliseconds,
-        lessThan(100),
-      );
+      expect(updated.jobId, 'j');
+      expect(updated.operation, ContentOperation.enhance);
+      expect(updated.resultText, 'final');
+      expect(updated.tokensUsed, 42);
     });
   });
 }

--- a/test/domain/entity/content_entity_test.dart
+++ b/test/domain/entity/content_entity_test.dart
@@ -45,6 +45,10 @@ void main() {
       expect(request.options, options);
     });
 
+    // Operation lives in the URL path now (`/api/contents/<op>`), not the
+    // request body. Options are flattened so optional hints (tone, length)
+    // map directly to BE DTO fields.
+
     test('toMap converts request without options to map', () {
       final request = ContentRequest(
         text: 'Sample text',
@@ -54,12 +58,12 @@ void main() {
       final map = request.toMap();
 
       expect(map['text'], 'Sample text');
-      expect(map['operation'], 'humanize');
+      expect(map.containsKey('operation'), false);
       expect(map.containsKey('options'), false);
     });
 
-    test('toMap converts request with options to map', () {
-      final options = {'level': 'advanced'};
+    test('toMap flattens options into the body', () {
+      final options = {'tone': 'formal', 'length': 'short'};
       final request = ContentRequest(
         text: 'Complex text',
         operation: ContentOperation.summarize,
@@ -69,11 +73,13 @@ void main() {
       final map = request.toMap();
 
       expect(map['text'], 'Complex text');
-      expect(map['operation'], 'summarize');
-      expect(map['options'], options);
+      expect(map['tone'], 'formal');
+      expect(map['length'], 'short');
+      expect(map.containsKey('options'), false);
+      expect(map.containsKey('operation'), false);
     });
 
-    test('toMap includes all operation types correctly', () {
+    test('toMap omits operation key for every operation type', () {
       final operations = [
         ContentOperation.enhance,
         ContentOperation.rewrite,
@@ -84,7 +90,9 @@ void main() {
       for (final op in operations) {
         final request = ContentRequest(text: 'text', operation: op);
         final map = request.toMap();
-        expect(map['operation'], op.apiPath);
+        expect(map.containsKey('operation'), false,
+            reason: 'operation $op should not appear in body');
+        expect(map['text'], 'text');
       }
     });
   });

--- a/test/domain/usecase/content_usecase_test.dart
+++ b/test/domain/usecase/content_usecase_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:boilerplate/domain/entity/content/content_item.dart';
 import 'package:boilerplate/domain/entity/content/content_operation.dart';
 import 'package:boilerplate/domain/entity/content/content_request.dart';
 import 'package:boilerplate/domain/entity/content/content_result.dart';
@@ -8,357 +9,177 @@ import 'package:boilerplate/domain/usecase/content/rewrite_content_usecase.dart'
 import 'package:boilerplate/domain/usecase/content/humanize_content_usecase.dart';
 import 'package:boilerplate/domain/usecase/content/summarize_content_usecase.dart';
 
-// Mock repository for testing
 class MockContentRepository implements ContentRepository {
   ContentRequest? lastRequest;
   ContentResult? resultToReturn;
-  List<ContentRequest> allRequests = [];
+  ContentResult? pollResultToReturn;
+  List<Map<String, dynamic>> projectsToReturn = const [];
+  List<ContentItem> contentsToReturn = const [];
+  final List<ContentRequest> allRequests = [];
 
   @override
-  Future<ContentResult> processContent(ContentRequest request) async {
+  Future<List<Map<String, dynamic>>> listProjects() async => projectsToReturn;
+
+  @override
+  Future<List<ContentItem>> listProjectContents(String projectId) async =>
+      contentsToReturn;
+
+  @override
+  Future<ContentResult> startProcess(ContentRequest request) async {
     lastRequest = request;
     allRequests.add(request);
-    return resultToReturn!;
+    return resultToReturn ??
+        ContentResult.jobCreated(
+          jobId: 'job-${request.contentId}',
+          operation: request.operation,
+        );
+  }
+
+  @override
+  Future<ContentResult?> pollByJob(String jobId) async {
+    return pollResultToReturn;
   }
 }
 
 void main() {
+  ContentRequest req(ContentOperation op,
+      {String contentId = 'cid-test', Map<String, dynamic>? options}) {
+    return ContentRequest(
+      contentId: contentId,
+      operation: op,
+      options: options,
+    );
+  }
+
   group('EnhanceContentUseCase', () {
-    late MockContentRepository mockRepository;
+    late MockContentRepository repo;
     late EnhanceContentUseCase useCase;
-    late ContentResult mockResult;
 
     setUp(() {
-      mockRepository = MockContentRepository();
-      useCase = EnhanceContentUseCase(mockRepository);
-      mockResult = ContentResult(
-        resultText: 'Enhanced content',
+      repo = MockContentRepository();
+      useCase = EnhanceContentUseCase(repo);
+    });
+
+    test('forces enhance operation regardless of incoming op', () async {
+      await useCase.call(params: req(ContentOperation.rewrite));
+      expect(repo.lastRequest!.operation, ContentOperation.enhance);
+    });
+
+    test('preserves contentId and options', () async {
+      final options = {'tone': 'formal'};
+      await useCase.call(
+        params: req(ContentOperation.enhance,
+            contentId: 'cid-1', options: options),
+      );
+      expect(repo.lastRequest!.contentId, 'cid-1');
+      expect(repo.lastRequest!.options, options);
+    });
+
+    test('returns the job ack from the repository', () async {
+      final ack = ContentResult.jobCreated(
+        jobId: 'job-abc',
         operation: ContentOperation.enhance,
-        tokensUsed: 50,
-        processedAt: DateTime.now(),
       );
-      mockRepository.resultToReturn = mockResult;
-    });
-
-    test('call enforces enhance operation', () async {
-      final request = ContentRequest(
-        text: 'Original text',
-        operation: ContentOperation.rewrite,
-      );
-
-      final result = await useCase.call(params: request);
-
-      expect(mockRepository.lastRequest!.operation, ContentOperation.enhance);
+      repo.resultToReturn = ack;
+      final result = await useCase.call(params: req(ContentOperation.enhance));
+      expect(result.jobId, 'job-abc');
       expect(result.operation, ContentOperation.enhance);
-    });
-
-    test('call preserves text from request', () async {
-      final inputText = 'Text to enhance';
-      final request = ContentRequest(
-        text: inputText,
-        operation: ContentOperation.summarize,
-      );
-
-      await useCase.call(params: request);
-
-      expect(mockRepository.lastRequest!.text, inputText);
-    });
-
-    test('call preserves options from request', () async {
-      final options = {'tone': 'formal', 'length': 'long'};
-      final request = ContentRequest(
-        text: 'Text',
-        operation: ContentOperation.rewrite,
-        options: options,
-      );
-
-      await useCase.call(params: request);
-
-      expect(mockRepository.lastRequest!.options, options);
-    });
-
-    test('call returns result from repository', () async {
-      final request = ContentRequest(
-        text: 'Text',
-        operation: ContentOperation.rewrite,
-      );
-
-      final result = await useCase.call(params: request);
-
-      expect(result, mockResult);
-      expect(result.resultText, 'Enhanced content');
-    });
-
-    test('call without options passes null options', () async {
-      final request = ContentRequest(
-        text: 'Text',
-        operation: ContentOperation.rewrite,
-      );
-
-      await useCase.call(params: request);
-
-      expect(mockRepository.lastRequest!.options, null);
     });
   });
 
   group('RewriteContentUseCase', () {
-    late MockContentRepository mockRepository;
+    late MockContentRepository repo;
     late RewriteContentUseCase useCase;
-    late ContentResult mockResult;
 
     setUp(() {
-      mockRepository = MockContentRepository();
-      useCase = RewriteContentUseCase(mockRepository);
-      mockResult = ContentResult(
-        resultText: 'Rewritten content',
-        operation: ContentOperation.rewrite,
-        tokensUsed: 60,
-        processedAt: DateTime.now(),
-      );
-      mockRepository.resultToReturn = mockResult;
+      repo = MockContentRepository();
+      useCase = RewriteContentUseCase(repo);
     });
 
-    test('call enforces rewrite operation', () async {
-      final request = ContentRequest(
-        text: 'Original text',
-        operation: ContentOperation.enhance,
-      );
-
-      final result = await useCase.call(params: request);
-
-      expect(mockRepository.lastRequest!.operation, ContentOperation.rewrite);
-      expect(result.operation, ContentOperation.rewrite);
+    test('forces rewrite operation', () async {
+      await useCase.call(params: req(ContentOperation.enhance));
+      expect(repo.lastRequest!.operation, ContentOperation.rewrite);
     });
 
-    test('call preserves text from request', () async {
-      final inputText = 'Text to rewrite';
-      final request = ContentRequest(
-        text: inputText,
-        operation: ContentOperation.humanize,
+    test('preserves contentId', () async {
+      await useCase.call(
+        params: req(ContentOperation.rewrite, contentId: 'cid-rw'),
       );
-
-      await useCase.call(params: request);
-
-      expect(mockRepository.lastRequest!.text, inputText);
-    });
-
-    test('call preserves options from request', () async {
-      final options = {'style': 'casual', 'complexity': 'high'};
-      final request = ContentRequest(
-        text: 'Text',
-        operation: ContentOperation.enhance,
-        options: options,
-      );
-
-      await useCase.call(params: request);
-
-      expect(mockRepository.lastRequest!.options, options);
-    });
-
-    test('call returns result from repository', () async {
-      final request = ContentRequest(
-        text: 'Text',
-        operation: ContentOperation.enhance,
-      );
-
-      final result = await useCase.call(params: request);
-
-      expect(result, mockResult);
-      expect(result.resultText, 'Rewritten content');
+      expect(repo.lastRequest!.contentId, 'cid-rw');
     });
   });
 
   group('HumanizeContentUseCase', () {
-    late MockContentRepository mockRepository;
+    late MockContentRepository repo;
     late HumanizeContentUseCase useCase;
-    late ContentResult mockResult;
 
     setUp(() {
-      mockRepository = MockContentRepository();
-      useCase = HumanizeContentUseCase(mockRepository);
-      mockResult = ContentResult(
-        resultText: 'Humanized content',
-        operation: ContentOperation.humanize,
-        tokensUsed: 40,
-        processedAt: DateTime.now(),
-      );
-      mockRepository.resultToReturn = mockResult;
+      repo = MockContentRepository();
+      useCase = HumanizeContentUseCase(repo);
     });
 
-    test('call enforces humanize operation', () async {
-      final request = ContentRequest(
-        text: 'Robotic text',
-        operation: ContentOperation.enhance,
-      );
-
-      final result = await useCase.call(params: request);
-
-      expect(mockRepository.lastRequest!.operation, ContentOperation.humanize);
-      expect(result.operation, ContentOperation.humanize);
-    });
-
-    test('call preserves text from request', () async {
-      final inputText = 'Text to humanize';
-      final request = ContentRequest(
-        text: inputText,
-        operation: ContentOperation.rewrite,
-      );
-
-      await useCase.call(params: request);
-
-      expect(mockRepository.lastRequest!.text, inputText);
-    });
-
-    test('call preserves options from request', () async {
-      final options = {'warmth': 'high'};
-      final request = ContentRequest(
-        text: 'Text',
-        operation: ContentOperation.summarize,
-        options: options,
-      );
-
-      await useCase.call(params: request);
-
-      expect(mockRepository.lastRequest!.options, options);
-    });
-
-    test('call returns result from repository', () async {
-      final request = ContentRequest(
-        text: 'Text',
-        operation: ContentOperation.enhance,
-      );
-
-      final result = await useCase.call(params: request);
-
-      expect(result, mockResult);
-      expect(result.resultText, 'Humanized content');
+    test('forces humanize operation', () async {
+      await useCase.call(params: req(ContentOperation.enhance));
+      expect(repo.lastRequest!.operation, ContentOperation.humanize);
     });
   });
 
   group('SummarizeContentUseCase', () {
-    late MockContentRepository mockRepository;
+    late MockContentRepository repo;
     late SummarizeContentUseCase useCase;
-    late ContentResult mockResult;
 
     setUp(() {
-      mockRepository = MockContentRepository();
-      useCase = SummarizeContentUseCase(mockRepository);
-      mockResult = ContentResult(
-        resultText: 'Summarized content',
-        operation: ContentOperation.summarize,
-        tokensUsed: 30,
-        processedAt: DateTime.now(),
-      );
-      mockRepository.resultToReturn = mockResult;
+      repo = MockContentRepository();
+      useCase = SummarizeContentUseCase(repo);
     });
 
-    test('call enforces summarize operation', () async {
-      final request = ContentRequest(
-        text: 'Long content',
-        operation: ContentOperation.enhance,
-      );
-
-      final result = await useCase.call(params: request);
-
-      expect(mockRepository.lastRequest!.operation, ContentOperation.summarize);
-      expect(result.operation, ContentOperation.summarize);
+    test('forces summarize operation', () async {
+      await useCase.call(params: req(ContentOperation.enhance));
+      expect(repo.lastRequest!.operation, ContentOperation.summarize);
     });
 
-    test('call preserves text from request', () async {
-      final inputText = 'Long text to summarize';
-      final request = ContentRequest(
-        text: inputText,
-        operation: ContentOperation.humanize,
+    test('preserves length option', () async {
+      await useCase.call(
+        params: req(ContentOperation.summarize,
+            options: {'length': 'short'}),
       );
-
-      await useCase.call(params: request);
-
-      expect(mockRepository.lastRequest!.text, inputText);
-    });
-
-    test('call preserves options from request', () async {
-      final options = {'length': 'short', 'bulletPoints': true};
-      final request = ContentRequest(
-        text: 'Text',
-        operation: ContentOperation.rewrite,
-        options: options,
-      );
-
-      await useCase.call(params: request);
-
-      expect(mockRepository.lastRequest!.options, options);
-    });
-
-    test('call returns result from repository', () async {
-      final request = ContentRequest(
-        text: 'Text',
-        operation: ContentOperation.enhance,
-      );
-
-      final result = await useCase.call(params: request);
-
-      expect(result, mockResult);
-      expect(result.resultText, 'Summarized content');
+      expect(repo.lastRequest!.options, {'length': 'short'});
     });
   });
 
   group('Content Use Cases Integration', () {
-    late MockContentRepository mockRepository;
+    test('each use case enforces its own operation', () async {
+      final repo = MockContentRepository();
+      final base = req(ContentOperation.enhance, contentId: 'cid-int');
 
-    setUp(() {
-      mockRepository = MockContentRepository();
+      await EnhanceContentUseCase(repo).call(params: base);
+      expect(repo.lastRequest!.operation, ContentOperation.enhance);
+
+      await RewriteContentUseCase(repo).call(params: base);
+      expect(repo.lastRequest!.operation, ContentOperation.rewrite);
+
+      await HumanizeContentUseCase(repo).call(params: base);
+      expect(repo.lastRequest!.operation, ContentOperation.humanize);
+
+      await SummarizeContentUseCase(repo).call(params: base);
+      expect(repo.lastRequest!.operation, ContentOperation.summarize);
     });
 
-    test('each use case enforces correct operation', () async {
-      final mockResult = ContentResult(
-        resultText: 'Result',
-        operation: ContentOperation.enhance,
-        processedAt: DateTime.now(),
-      );
-      mockRepository.resultToReturn = mockResult;
+    test('mock tracks every dispatched request', () async {
+      final repo = MockContentRepository();
+      final r = req(ContentOperation.enhance);
 
-      final request = ContentRequest(
-        text: 'Input',
-        operation: ContentOperation.enhance,
-      );
+      await EnhanceContentUseCase(repo).call(params: r);
+      await RewriteContentUseCase(repo).call(params: r);
+      await HumanizeContentUseCase(repo).call(params: r);
 
-      final enhance = EnhanceContentUseCase(mockRepository);
-      final rewrite = RewriteContentUseCase(mockRepository);
-      final humanize = HumanizeContentUseCase(mockRepository);
-      final summarize = SummarizeContentUseCase(mockRepository);
-
-      await enhance.call(params: request);
-      expect(mockRepository.lastRequest!.operation, ContentOperation.enhance);
-
-      await rewrite.call(params: request);
-      expect(mockRepository.lastRequest!.operation, ContentOperation.rewrite);
-
-      await humanize.call(params: request);
-      expect(mockRepository.lastRequest!.operation, ContentOperation.humanize);
-
-      await summarize.call(params: request);
-      expect(mockRepository.lastRequest!.operation, ContentOperation.summarize);
+      expect(repo.allRequests.length, 3);
     });
 
-    test('all requests are tracked by mock repository', () async {
-      final mockResult = ContentResult(
-        resultText: 'Result',
-        operation: ContentOperation.enhance,
-        processedAt: DateTime.now(),
-      );
-      mockRepository.resultToReturn = mockResult;
-
-      final request = ContentRequest(text: 'Text', operation: ContentOperation.enhance);
-
-      final enhance = EnhanceContentUseCase(mockRepository);
-      final rewrite = RewriteContentUseCase(mockRepository);
-
-      await enhance.call(params: request);
-      await rewrite.call(params: request);
-
-      expect(mockRepository.allRequests.length, 2);
-      expect(mockRepository.allRequests[0].operation, ContentOperation.enhance);
-      expect(mockRepository.allRequests[1].operation, ContentOperation.rewrite);
+    test('repository.pollByJob returns null while job is in flight', () async {
+      final repo = MockContentRepository()..pollResultToReturn = null;
+      final result = await repo.pollByJob('any');
+      expect(result, isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary

Phase 2 integration for **Feature 8 — Content Enhancement**
([#42](https://github.com/phhaifit/mobile_ai_aeo/issues/42)).

This PR pivots Feature 8 from the original Phase 1 "paste raw text"
screen to a flow that matches the actual AEO product: pick one of your
existing draft posts, optionally tell the AI what to focus on, then run
enhance / rewrite / humanize / summarize against it. The four ops all
reuse the existing N8N regenerate pipeline on BE — see paired BE PR
[GEO-Brand-Visibility/geo-brand-visibility-be#148](https://github.com/GEO-Brand-Visibility/geo-brand-visibility-be/pull/148).

## What changed

### Domain
- New `ContentItem` projection for the picker (id, title, body,
  contentType, status, topicName, plus `isEnhanceable` so DRAFTING /
  FAILED rows can't be selected).
- `ContentRequest` now carries `contentId` (operation lives in the URL,
  not the body); `options` flattens into the request body so
  `tone` / `length` / `customInstruction` map 1:1 to the BE DTO.
- `ContentResult` models the async ack (`jobId`) plus the regenerated
  body fetched via `pollByJob`.

### Data
- `ContentApi` gains `listProjects`, `listProjectContents(projectId)`,
  `startProcess(request)`, `pollByJob(jobId)`.
- `ContentRepository` interface + impl updated; old `processContent`
  renamed `startProcess`.
- `Endpoints` paths now match BE PR #148:
  - `POST /api/contents/:id/{enhance|rewrite|humanize|summarize}`
  - `GET  /api/contents/by-job/:jobId`
  - `GET  /api/projects/:projectId/contents`

### Presentation
- `ContentEnhancementStore` loads the user's first project + its
  contents on screen init, tracks `selectedContent`, `selectedTone`,
  `selectedLength`, `customInstruction`. Polls the regenerate job
  every 3 s up to 60 attempts (~3 min) then surfaces a timeout error.
- **MobX subscription fix:** observable reads inside `ListView.itemBuilder`
  do NOT establish a subscription (lazy callback). Selected card was
  never re-rendering because of this. Fixed by reading
  `availableContents` + `selectedContent?.id` synchronously inside the
  picker's Observer and passing them down as plain values.
- `content_enhancement_screen.dart` rewritten:
  - Picker section with strong selected-state visuals (full accent
    fill, white check icon, "✓ SELECTED" pill, shadow).
  - New `CustomizationPanel` widget — free-text "tell the AI what to
    focus on" (max 500 chars) + tone chips (enhance/rewrite/humanize)
    or length chips (summarize).
  - Selected draft preview: full body in a scrollable container.
  - New `BeforeAfterWidget` — original vs result side-by-side on
    wide screens, stacked on phone widths, copy button on the result
    panel.

### Tests
- `content_entity_test.dart` covers the new `contentId` body shape +
  `jobCreated` factory + `copyWith`.
- `content_usecase_test.dart` mock implements the new repository
  interface and validates each use case forces its op regardless of
  the incoming request.

## Acceptance criteria for #42

- [x] All 4 actions (enhance / rewrite / humanize / summarize) call
      real AI APIs through the regenerate pipeline.
- [x] Results returned and displayed correctly — Before/After view.
- [x] Async processing states (loading / success / error) handled
      properly — polling, timeout, snackbar errors via `ErrorStore`.

## Backend dependency

Requires BE PR
[GEO-Brand-Visibility/geo-brand-visibility-be#148](https://github.com/GEO-Brand-Visibility/geo-brand-visibility-be/pull/148)
merged + deployed first. Until then, the FE handles the 404 gracefully
and the picker still works.

## Local setup

`.env.dev` (gitignored — per dev machine):
```
ENVIRONMENT=dev
API_BASE_URL=https://app.aeo.how
AI_API_BASE_URL=https://app.aeo.how
```

> **Note for reviewers running the web target locally:** because Web
> AEO sets `access_token` as a SameSite=Lax cookie, browsers strip it
> from cross-origin XHR (`localhost:3000` → `app.aeo.how`). The simplest
> workaround for local verification is a small reverse proxy that
> injects the cookie server-side; see the dev-only script under
> `.claude/skills/chrome-devtools/scripts/_aeo-cookie-proxy.mjs` (not
> committed — local debug only). On a real device this isn't an issue
> because the FE is same-origin once shipped.

## Test plan

- [x] `flutter analyze` — no issues across changed files.
- [x] `flutter test test/domain/` — entity + use-case suites green
      (24 / 24).
- [x] Local web verify: app loads project list → contents → picker
      shows the user's drafts; click op → `POST /api/contents/<id>/<op>`
      with cookie auth fires correctly. Currently 404 because BE PR
      #148 isn't deployed yet.
- [ ] Post BE deploy: full happy path — pick post → run op → polling
      kicks in → Before/After view renders the regenerated body.
- [ ] Edge cases: empty project (empty-state copy), DRAFTING /
      FAILED rows are disabled in the picker, polling timeout after
      ~3 min surfaces a clear error.

## Screenshots / video

To be attached after BE PR #148 deploys + simulator run captures the
full happy path.

## Related

- BE PR: [GEO-Brand-Visibility/geo-brand-visibility-be#148](https://github.com/GEO-Brand-Visibility/geo-brand-visibility-be/pull/148)
- Closes #42 once BE deploys.
